### PR TITLE
Redirect file requests with no slug + accessPolicy changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,29 @@ app.use(async (req, res, next) => {
 // Serve static files from public directory.
 app.use(express.static(conf.publicDir));
 
+// Redirect file requests with no slug.
+app.get('/files/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const entry = await dirEntriesService.instance.get(id);
+
+    if (!testAccessPolicy(req, entry)) {
+      return handleAccessPolicyViolation(req, res, entry);
+    }
+
+    if (!entry || entry.type !== 'file') {
+      return res.sendStatus(404);
+    }
+
+    res.redirect(`/files/${id}/${entry.name}`);
+  }
+  catch (err) {
+    console.error(err);
+    res.send(err);
+  }
+});
+
 // Serve uploaded files.
 app.get('/files/:id/:slug', async (req, res) => {
   try {

--- a/utils/handleAccessPolicyViolation.js
+++ b/utils/handleAccessPolicyViolation.js
@@ -1,0 +1,16 @@
+module.exports = (req, res, entry) => {
+  console.warn(
+    `[WARN] accessPolicy violation attempt.`,
+
+    JSON.stringify({
+      clientAddr: req.ip,
+      slug: req.params.slug,
+      accessPolicy: entry.accessPolicy,
+      owner: entry.owner,
+      name: entry.name,
+      id: entry._id,
+    }),
+  );
+
+  res.sendStatus(404);
+};

--- a/utils/testAccessPolicy.js
+++ b/utils/testAccessPolicy.js
@@ -1,0 +1,20 @@
+module.exports = (req, entry) => {
+  switch (entry.accessPolicy) {
+    case 'auth': return !!req.token;
+    case 'public': return true;
+
+    default:
+      console.warn(
+        `[WARN] Invalid or unsupported accessPolicy.`,
+
+        JSON.stringify({
+          accessPolicy: entry.accessPolicy,
+          owner: entry.owner,
+          name: entry.name,
+          id: entry._id,
+        }),
+      );
+
+      return false;
+  }
+};


### PR DESCRIPTION
This PR also implements:

* Support for `accessPolicy: 'public'`.
* Better `accessPolicy` violation logs.