### PR TITLE
dirEntriesService: Implement new GET method.

### DIFF
--- a/entities/dirEntry/model.js
+++ b/entities/dirEntry/model.js
@@ -1,2 +1,17 @@
 const createModel = require('../../utils/createModel');
 module.exports = createModel('dirEntries');
+
+// Create the global root dirEntry (if it doesn't exist).
+module.exports.update(
+  { _id: 'root' },
+  {},
+
+  { upsert: true },
+
+  err => {
+    if (err) {
+      console.error(err);
+      process.exit(-1);
+    }
+  },
+);

--- a/hooks/requireAuthToken.js
+++ b/hooks/requireAuthToken.js
@@ -1,5 +1,13 @@
+const getOriginalCtx = require('../utils/getOriginalCtx');
+
 module.exports = () => ctx => {
-  if (!ctx.params.token) {
+  const originalCtx = getOriginalCtx(ctx);
+
+  if (
+    !originalCtx ||
+    !originalCtx.params ||
+    !originalCtx.params.token
+  ) {
     throw new Error(401);
   }
 };

--- a/utils/getOriginalCtx.js
+++ b/utils/getOriginalCtx.js
@@ -1,0 +1,8 @@
+module.exports = ctx => {
+  console.log(ctx.params.originalCtx);
+  if (ctx.params && ctx.params.originalCtx) {
+    return ctx.params.originalCtx;
+  }
+
+  return ctx;
+};


### PR DESCRIPTION
Mudanças:

❶ O servidor agora cria uma nova `dirEntry` (`{ _id: 'root' }`) automaticamente ao ser inicializado, caso uma `dirEntry` com essa ID ainda não exista. O ideal seria que o "root" não existisse de fato no banco, que fosse virtual, mas enfim; muita mão fazer o Feathers "play nice" com isso, mais fácil criar uma entrada placeholder dessas no banco mesmo.

❷ O Feathers permite chamadas externas e internas aos seus serviços. A maioria dos serviços representa coleções no banco de dados (coleções são conjuntos de documentos do mesmo tipo, por exemplo: `users`, `uploads`, `dirEntries`, etc).

As chamadas externas são as que vem de requisições de clientes conectados ao servidor pela Internet, e o servidor carrega o token do cabeçalho `Authorization` e insere nos parâmetros da chamada automaticamente.

As chamadas internas são feitas pelo próprio servidor, geralmente em hooks (funções chamadas antes ou depois do Feathers acessar de fato o banco de dados) pra carregar dados adicionais relacionados a uma entidade (e.g. parent e child `dirEntries`), e, ao contrário das chamadas externas, o servidor não tem condições de inserir o token do cabeçalho `Authorization` automaticamente, porque o cabeçalho `Authorization` é um cabeçalho do protocolo HTTP, que só é usado no processamento de chamadas externas.

Graças a um `before-hook` chamado `requireAuthToken` que usamos pra exigir uma token válida antes de processar qualquer chamada de serviço (tanto externa quanto interna) que requeira autenticação, tanto as chamadas externas quanto internas que não possuam um token válido são bloqueadas antes de chegar ao banco de dados.

Pra que as chamadas internas não sejam bloqueadas pelo hook `requireAuthToken`, passo como parâmetro das chamadas internas o objeto de contexto do Feathers (`ctx`) da chamada original (externa) usando o nome `originalCtx`.

Adaptei o `requireAuthToken` pra verificar também se não existe um token válido em `originalCtx.params.token`, de forma que chamadas internas contendo um `originalCtx` de uma chamada externa usem automaticamente o token da chamada externa.

Implementei também o helper `getOriginalCtx(ctx)`, que retorna `ctx.params.originalCtx` (se houver) ou o próprio `ctx` passado por parâmetro. Esse helper é usado em `requireAuthToken` e no próprio `dirEntriesService` (`find before-hook`) pra encontrar o `ctx` adequado (o externo, que contenha os tokens validados; pode ser o próprio `ctx` no caso de uma chamada externa quanto o `ctx.params.originalCtx` no caso de uma chamada interna).

❸ Finalmente: Nesse novo método `GET` do `dirEntriesService`, além de retornar do banco os campos básicos do `dirEntry` requisitado (`_id`, `parent`, `type`, `name`, etc; o que é feito automaticamente pelo Feathers), adicionei um `after-hook` que usa um loop pra carregar os `dirEntries` de todos os parents também, até a raíz. Esse loop utiliza o sistema de chamadas internas do Feathers (por isso precisei das modificações explicadas no item 2).